### PR TITLE
README.md: use valid branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run repo init to bring down the latest version of Repo with all its most recent 
 
 To check out a branch other than "master", specify it with -b:
 
-	$ repo init -u git://github.com/Angstrom-distribution/angstrom-manifest -b angstrom-v2013.12-yocto1.5
+	$ repo init -u git://github.com/Angstrom-distribution/angstrom-manifest -b angstrom-v2015.06-yocto1.8
 
 When prompted, configure Repo with your real name and email address. 
 


### PR DESCRIPTION
The README talks about optionally using a branch, but the branch it specifies
doesn't exist. Switch to use one that does.

Signed-off-by: Trevor Woerner twoerner@gmail.com
