### PR TITLE
setup-environment-internal: select machine from list

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -50,6 +50,7 @@ BSPLAYERS ?= " \
   ${TOPDIR}/sources/meta-smartphone/meta-openmoko \
   ${TOPDIR}/sources/meta-smartphone/meta-palm \
   ${TOPDIR}/sources/meta-handheld \
+  ${TOPDIR}/sources/meta-opie \
   ${TOPDIR}/sources/meta-intel \
   ${TOPDIR}/sources/meta-intel/meta-sugarbay \
   ${TOPDIR}/sources/meta-intel/meta-crownbay \
@@ -64,6 +65,11 @@ BSPLAYERS ?= " \
   ${TOPDIR}/sources/meta-exynos \
   ${TOPDIR}/sources/meta-gumstix-community \
   ${TOPDIR}/sources/meta-qualcomm \
+  ${TOPDIR}/sources/meta-ettus \
+  ${TOPDIR}/sources/meta-openpandora \
+  ${TOPDIR}/sources/meta-edison \
+  ${TOPDIR}/sources/meta-xilinx \
+  ${TOPDIR}/sources/meta-96boards \
 "
 
 # Add your overlay location to EXTRALAYERS

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -23,7 +23,22 @@ if [ "$(whoami)" = "root" ]; then
     echo "ERROR: do not use the BSP as root. Exiting..."
 fi
 
+OEROOT=${PWD}
+cd $OEROOT
+
 if [ -z "${MACHINE}" ]; then
+    MACHINELIST=`ls $OEROOT/sources/*/conf/machine/*.conf | sed s/\.conf//g | sed -r 's/^.+\///' | sort`
+    PS3='Please choose your machine by entering its number: '
+    select MACHINE in $MACHINELIST; do
+        if [ -n "$MACHINE" ]; then
+            break
+        fi
+        echo "invalid choice, please try again"
+    done
+fi
+
+# guard against Ctrl-D
+if [ -z "$MACHINE" ]; then
     MACHINE='beaglebone'
 fi
 
@@ -31,10 +46,7 @@ if [ -z "${SDKMACHINE}" ]; then
     SDKMACHINE='x86_64'
 fi
 
-OEROOT=${PWD}
 TEMPLATES=${OEROOT}/sources/manifest
-
-cd $OEROOT
 
 # Clean up PATH, because if it includes tokens to current directories somehow,
 # wrong binaries can be used instead of the expected ones during task execution


### PR DESCRIPTION
If the user hasn't chosen a MACHINE, present an alphabetical list of known
machines from which they can choose (by number).

Signed-off-by: Trevor Woerner twoerner@gmail.com
