### PR TITLE
setup-environment-internal: exit if root

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -21,6 +21,7 @@
 
 if [ "$(whoami)" = "root" ]; then
     echo "ERROR: do not use the BSP as root. Exiting..."
+    return
 fi
 
 OEROOT=${PWD}


### PR DESCRIPTION
Make sure to terminate the script if it is discovered it is being run as root.

Signed-off-by: Trevor Woerner twoerner@gmail.com
