### PR TITLE
setup-environment-internal: enable auto resizing

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -41,7 +41,7 @@ if [ -z "${MACHINE}" ]; then
             MACHINETABLE="${MACHINETABLE} $(echo $ITEM | cut -d'(' -f1) $(echo $ITEM | cut -d'(' -f2 | cut -d')' -f1) OFF\n"
         done
         MACHINE=$(whiptail --title "Available Machines" --radiolist \
-            "Please choose a machine" 30 66 20 \
+            "Please choose a machine" 0 0 20 \
             ${MACHINETABLE} 3>&1 1>&2 2>&3)
         unset MACHINETABLE
     fi
@@ -53,7 +53,7 @@ if [ -z "${MACHINE}" ]; then
             for ITEM in $MACHLAYERS; do
                 MACHINETABLE="$MACHINETABLE $(echo $ITEM | cut -d'(' -f1) $(echo $ITEM | cut -d'(' -f2 | cut -d')' -f1)"
             done
-            MACHINE=$(dialog --title "Available Machines" --menu "Please choose a machine" 30 66 20 $MACHINETABLE 3>&1 1>&2 2>&3)
+            MACHINE=$(dialog --title "Available Machines" --menu "Please choose a machine" 0 0 20 $MACHINETABLE 3>&1 1>&2 2>&3)
         fi
     fi
     unset MACHINETABLE


### PR DESCRIPTION
Allow both the "whiptail" and "dialog" tables to be auto-resized (i.e. set
width and height to zero). The table widths will try to accommodate the full
description text.

Signed-off-by: Trevor Woerner twoerner@gmail.com
