### PR TITLE
adjusted pathing for setup-environment copyfile, per issue44

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="Angstrom-distribution/meta-angstrom" path="layers/meta-angstrom" remote="github" revision="angstrom-v2019.06-warrior">
-    <copyfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
+    <copyfile dest="setup-environment" src="setup-environment-internal"/>
   </project>
   <project name="EmbeddedAndroid/meta-rtlwifi" path="layers/meta-rtlwifi" remote="github" revision="3d920444e433ceddecb7809da0ebab278d57e1ef"/>
   <project name="Freescale/meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" remote="github"/>


### PR DESCRIPTION
This fixes the issue described in #44, for the 2019.06-warrior branch only!  
There is a corresponding PR in the meta-angstrom repo. The only real change here is to the pathing of the copyfile directive in default.xml